### PR TITLE
Add browser annotations for WIP posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<article class="post detailed">
+<article class="post detailed"{% if page.wip or page.draft %} data-wip-annotations{% endif %}>
   <h1>{{ page.title }}</h1>
 
   <div>
@@ -26,7 +26,7 @@ layout: default
   {% if page.wip or page.draft %}
   <div class="wip-callout">
     <strong>Work in progress.</strong>
-    This post is still being written and will likely change.
+    This post is still being written and will likely change. Click any text line to save a browser-only note. Export from the console with <code>exportWipAnnotations()</code>, <code>exportWipAnnotations('json')</code>, or <code>exportWipAnnotations('tsv')</code>.
   </div>
   {% endif %}
 
@@ -51,3 +51,7 @@ layout: default
 
   {% include disqus.html %}
 </article>
+
+{% if page.wip or page.draft %}
+<script src="{{ site.baseurl }}/assets/wip-annotations.js" defer></script>
+{% endif %}

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -1565,3 +1565,52 @@ details.dsa-toggle[open] > summary::after {
     transition: none;
   }
 }
+
+.wip-annotation-line {
+  position: relative;
+  cursor: copy;
+  transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.wip-annotation-line::before {
+  content: attr(data-annotation-line);
+  position: absolute;
+  right: calc(100% + 10px);
+  top: 0.15em;
+  min-width: 2.5em;
+  color: rgba(64, 64, 64, 0.35);
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: right;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.wip-annotation-line:hover {
+  background: rgba(255, 245, 157, 0.35);
+  box-shadow: -4px 0 0 rgba(255, 213, 79, 0.65);
+}
+
+.wip-annotation-line:hover::before,
+.wip-annotation-line--commented::before {
+  opacity: 1;
+}
+
+.wip-annotation-line--commented {
+  background: rgba(200, 230, 201, 0.35);
+  box-shadow: -4px 0 0 rgba(76, 175, 80, 0.65);
+}
+
+.wip-callout code {
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 0.9em;
+}
+
+@include mobile {
+  .wip-annotation-line::before {
+    right: calc(100% + 4px);
+    min-width: 1.8em;
+  }
+}

--- a/assets/wip-annotations.js
+++ b/assets/wip-annotations.js
@@ -1,0 +1,137 @@
+(function () {
+  'use strict';
+
+  var root = document.querySelector('[data-wip-annotations]');
+  if (!root || !window.localStorage) {
+    return;
+  }
+
+  var entry = root.querySelector('.entry');
+  if (!entry) {
+    return;
+  }
+
+  var storageKey = 'wip-annotations:' + window.location.pathname;
+  var selector = 'p, li, blockquote, h2, h3, h4, h5, h6';
+  var annotatedNodes = Array.prototype.slice.call(entry.querySelectorAll(selector)).filter(function (node) {
+    return node.textContent.trim().length > 0 && !node.closest('.annotation-ignore');
+  });
+
+  function readStore() {
+    try {
+      return JSON.parse(window.localStorage.getItem(storageKey)) || {};
+    } catch (error) {
+      return {};
+    }
+  }
+
+  function writeStore(store) {
+    window.localStorage.setItem(storageKey, JSON.stringify(store));
+  }
+
+  function quoteFor(node) {
+    return node.textContent.replace(/\s+/g, ' ').trim();
+  }
+
+  function updateNodeState(node, comment) {
+    if (comment) {
+      node.classList.add('wip-annotation-line--commented');
+      node.setAttribute('title', 'Annotation: ' + comment);
+    } else {
+      node.classList.remove('wip-annotation-line--commented');
+      node.removeAttribute('title');
+    }
+  }
+
+  function annotateLine(node) {
+    var line = node.getAttribute('data-annotation-line');
+    var store = readStore();
+    var existing = store[line] && store[line].comment ? store[line].comment : '';
+    var comment = window.prompt('Comment for line ' + line + ':', existing);
+
+    if (comment === null) {
+      return;
+    }
+
+    comment = comment.trim();
+    if (comment) {
+      store[line] = {
+        line: Number(line),
+        quote: quoteFor(node),
+        comment: comment,
+        updatedAt: new Date().toISOString()
+      };
+    } else {
+      delete store[line];
+    }
+
+    writeStore(store);
+    updateNodeState(node, comment);
+  }
+
+  function sortedAnnotations() {
+    var store = readStore();
+    return Object.keys(store).map(function (line) {
+      return store[line];
+    }).sort(function (a, b) {
+      return a.line - b.line;
+    });
+  }
+
+  function formatMarkdown(items) {
+    return items.map(function (item) {
+      return '- Line ' + item.line + '\n  > ' + item.quote + '\n\n  ' + item.comment;
+    }).join('\n\n');
+  }
+
+  function formatTsv(items) {
+    var escapeCell = function (value) {
+      return String(value).replace(/\t/g, ' ').replace(/\r?\n/g, ' ');
+    };
+    return ['line\tquote\tcomment'].concat(items.map(function (item) {
+      return [item.line, item.quote, item.comment].map(escapeCell).join('\t');
+    })).join('\n');
+  }
+
+  function exportAnnotations(format) {
+    var items = sortedAnnotations();
+    var outputFormat = format || 'markdown';
+    var output;
+
+    if (outputFormat === 'json') {
+      output = JSON.stringify(items, null, 2);
+    } else if (outputFormat === 'tsv') {
+      output = formatTsv(items);
+    } else {
+      output = formatMarkdown(items);
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(output).catch(function () {});
+    }
+
+    return output;
+  }
+
+  window.exportWipAnnotations = exportAnnotations;
+  window.clearWipAnnotations = function () {
+    window.localStorage.removeItem(storageKey);
+    annotatedNodes.forEach(function (node) {
+      updateNodeState(node, '');
+    });
+  };
+
+  var store = readStore();
+  annotatedNodes.forEach(function (node, index) {
+    var line = String(index + 1);
+    node.classList.add('wip-annotation-line');
+    node.setAttribute('data-annotation-line', line);
+    updateNodeState(node, store[line] && store[line].comment);
+    node.addEventListener('click', function (event) {
+      if (event.target.closest('a, button, input, textarea, select, label')) {
+        return;
+      }
+      annotateLine(node);
+    });
+  });
+}());


### PR DESCRIPTION
### Motivation
- Allow authors to make quick, browser-only line annotations on work-in-progress posts without adding a UI backend, keeping notes in `localStorage` and making them easy to export. 
- Provide a lightweight, non-intrusive workflow that works entirely in the reader's browser and only activates for `wip`/`draft` posts.

### Description
- Make post pages opt into annotations by adding a conditional `data-wip-annotations` hook and inline usage hint in `_layouts/post.html`, and conditionally load the annotation script for `wip`/`draft` posts. 
- Add `assets/wip-annotations.js` which numbers annotatable blocks, stores/edit/removes comments in `localStorage`, and exposes `exportWipAnnotations()` (Markdown/JSON/TSV) and `clearWipAnnotations()` on `window`, with best-effort clipboard write. 
- Add CSS in `assets/style.scss` for `.wip-annotation-line`, showing gutter line numbers, hover highlight, and a distinct style for commented lines, plus small styling for the updated `wip` callout code.

### Testing
- Ran a JavaScript syntax check with `node --check assets/wip-annotations.js`, which succeeded. 
- Attempted site build with `bundle exec jekyll build`, which could not run because the local environment lacked the bundled `jekyll` executable. 
- Attempted `bundle install && bundle exec jekyll build`, which failed due to `rubygems.org` returning `403 Forbidden` while fetching gems. 
- Attempted a Liquid render test via Ruby (`require 'liquid'`), which failed because the `liquid` gem was not available in the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a424cdb7f60832e9f85342ca95b5e1b)